### PR TITLE
Updated distribution list instruction

### DIFF
--- a/Instructions/10997A_LAB_AK_04.md
+++ b/Instructions/10997A_LAB_AK_04.md
@@ -39,9 +39,9 @@
 
 3. In the  **Create a group** window, in the **Group name** text box, type **DLGroup1**.
 
-4. In the  **Group email address** text box, type **dlgroup1**.
+4. In the  **Alias** text box, type **dlgroup1**.
 
-5. In the  **Privacy** drop-down list, select **Private - Only members can see content**.
+5. In the  **Group email address** text box, type **dlgroup1**.
 
 6. In the  **Language** drop-down list, select your language. If it is not listed, select **English (United States)**.
 


### PR DESCRIPTION
Added 'Alias' text field and remove 'Private - only member can see the content'. That part is meant for Office 365 groups, not for distribution lists.