### PR TITLE
Rephrased to eliminate confusion

### DIFF
--- a/Instructions/10997A_LAB_08.md
+++ b/Instructions/10997A_LAB_08.md
@@ -412,7 +412,7 @@ Note: You might have to click  **Other** in the middle pane to see the message. 
 
   - Notify internal senders when a message is blocked
 
-  - Notify  **Holly@Adatumxxyyy.onmicrosoft.com** when messages from internal or external senders are blocked
+  - Notify  **Holly@Adatumxxyyy.onmicrosoft.com** about undelivered messages from internal or external senders
 
 
 


### PR DESCRIPTION
Set "undelivered messages from internal or external senders" to reflect the options in the Anti-malware policy