### PR TITLE
Fixed example xml file

### DIFF
--- a/Instructions/10997C_LAB_AK_07.md
+++ b/Instructions/10997C_LAB_AK_07.md
@@ -87,7 +87,7 @@ In  **File Explorer**, in Office folder, right-click  **configuration-Office365-
 ```xml
 <Configuration>
 
- <Add SourcePath= "\\LON-CL1\Office16" OfficeClientEdition="32" Channel="Monthly">
+ <Add SourcePath= "\\LON-CL1\Office\" OfficeClientEdition="32" Channel="Monthly">
     <Product ID="O365ProPlusRetail">
      <Language ID="en-us" />
    </Product>


### PR DESCRIPTION
Task 2, step 6 shows what the xml file should look like, but in this version of the lab, we are using \\LON-CL1\Office\ not \\LON-CL1\Office**_16_**\.